### PR TITLE
Fix typo and syntax error

### DIFF
--- a/docs/handbook/04_streams.md
+++ b/docs/handbook/04_streams.md
@@ -101,8 +101,8 @@ class MessagesController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.append :messages, partial: "messages/message",
-          locals: { message: message }, formats: :html %>
+        render turbo_stream: turbo_stream.append(:messages, partial: "messages/message",
+          locals: { message: message }, formats: :html)
       end
 
       format.html { redirect_to messages_url }


### PR DESCRIPTION
- `%>` is typo
- Add  `()` after `append` to avoid syntax error